### PR TITLE
SUPPORT-1771: Applied patch to read_time module

### DIFF
--- a/sites/all/modules/contrib/read_time/read_time.module
+++ b/sites/all/modules/contrib/read_time/read_time.module
@@ -12,6 +12,7 @@ function read_time_form_node_type_form_alter(&$form, &$form_state, $form_id) {
   $defaults = read_time_defaults();
 
   // Get text fields in this bundle.
+  $fields = array();
   $field_instances = field_info_instances('node', $type->type);
   foreach ($field_instances as $field => $field_instance) {
     $field_info = field_info_field($field);


### PR DESCRIPTION
Applies patch (https://www.drupal.org/files/issues/fix_invalid_argument-2683245-4.patch) from https://www.drupal.org/project/read_time/issues/2683245

to fix issue with

Warning: Invalid argument supplied for foreach() i read_time_calculate() (linje 183 af [path]/htdocs/sites/all/modules/contrib/read_time/read_time.module).